### PR TITLE
Add CustomerNonExistent error to retrieve workflow

### DIFF
--- a/cmd/customer-svc/test/integration/remove_integration_test.go
+++ b/cmd/customer-svc/test/integration/remove_integration_test.go
@@ -1,0 +1,73 @@
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/albertowusuasare/customer-app/cmd/customer-svc/handler"
+	"github.com/albertowusuasare/customer-app/cmd/customer-svc/pkg"
+)
+
+func TestRemove(t *testing.T) {
+	// Initialize test server
+	app := pkg.InmemApp()
+	ts := httptest.NewServer(handler.Handle(app))
+
+	// Create customer
+	customer := CreateTestDataCustomer(ts)
+	customerID := customer.CustomerID
+
+	// Remove customer
+	res := doRemove(customerID, ts)
+	status := res.StatusCode
+	expectedStatus := 204
+	if status != expectedStatus {
+		t.Errorf("Expected http status %d but got %d", expectedStatus, status)
+	}
+
+	// Assert customer does not exist
+	testCustomerDoesNotExist(customerID, ts, t)
+}
+
+func doRemove(customerID string, ts *httptest.Server) *http.Response {
+	URL := fmt.Sprintf("%s/customers/%s", ts.URL, customerID)
+	req, reqErr := http.NewRequest(http.MethodDelete, URL, nil)
+	if reqErr != nil {
+		log.Fatal(reqErr)
+	}
+	client := &http.Client{}
+	res, callErr := client.Do(req)
+	if callErr != nil {
+		log.Fatal(callErr)
+	}
+	return res
+}
+
+func testCustomerDoesNotExist(customerID string, ts *httptest.Server, t *testing.T) {
+	URL := fmt.Sprintf("%s/customers/%s", ts.URL, customerID)
+	res, err := http.Get(URL)
+	if err != nil {
+		log.Fatal(err)
+	}
+	statusCode := res.StatusCode
+	if statusCode != http.StatusNotFound {
+		t.Fatalf("customer retrieval for removed customer returned status %d instead of %d", statusCode, http.StatusNotFound)
+	}
+
+	t.Run("error_body_asertion", func(t *testing.T) {
+		b, _ := ioutil.ReadAll(res.Body)
+		errDTO := handler.CustomerRetrieveErrorDTO{}
+		UnMarshal(b, &errDTO)
+
+		e := fmt.Sprintf("No record exits for customerID=%s", customerID)
+		a := errDTO.Message
+		if e != a {
+			t.Errorf("Expected error message=%s but got=%s", e, a)
+		}
+	})
+
+}

--- a/internal/retrieving/error.go
+++ b/internal/retrieving/error.go
@@ -1,0 +1,13 @@
+package retrieving
+
+import "fmt"
+
+// CustomerNonExistent is a representation of the error returned when a non existent customer is retrieved
+type CustomerNonExistent struct {
+	CustomerID string
+}
+
+// Error is the implementation of the Error interface on CustomerNonExistent
+func (e CustomerNonExistent) Error() string {
+	return fmt.Sprintf("No record exits for customerID=%s", e.CustomerID)
+}

--- a/internal/storage/customer.go
+++ b/internal/storage/customer.go
@@ -11,8 +11,10 @@ import (
 // A unique id for the customer will be generated using genUUIDStr
 type InsertCustomerFunc func(unPersistedCustomer adding.UnPersistedCustomer, genUUIDStr uuid.GenFunc) adding.PersistedCustomer
 
-// RetrieveCustomerFunc retrieve a customer in the data store corresponding to custoemrId
-type RetrieveCustomerFunc func(customerId string) retrieving.Customer
+// RetrieveCustomerFunc retrieve a customer in the data store corresponding to customerId
+// when error is nil. An error is returned if a customer record cannot be found for customerId.
+// In that case retrieving.CustomerNonExistent is returned
+type RetrieveCustomerFunc func(customerId string) (*retrieving.Customer, error)
 
 // RetrieveCustomersFunc retrieves multiple customers based on the query criteria defined in 'request'.
 type RetrieveCustomersFunc func(request retrieving.MultiRequest) []retrieving.Customer

--- a/internal/storage/inmem/customerdoc.go
+++ b/internal/storage/inmem/customerdoc.go
@@ -60,10 +60,15 @@ func customerDocumentFromUnPersistedCustomer(customer adding.UnPersistedCustomer
 
 // RetrieveCustomer returns an in memory implementation of customer retrieval
 func RetrieveCustomer() storage.RetrieveCustomerFunc {
-	return func(customerId string) retrieving.Customer {
-		log.Printf("Retrieving customerId=%s from the in memory database", customerId)
-		customerDoc := customerCollection[customerId]
-		return customerFromCustomerDoc(customerDoc)
+	return func(customerID string) (*retrieving.Customer, error) {
+		log.Printf("Retrieving customerId=%s from the in memory database", customerID)
+		customerDoc, present := customerCollection[customerID]
+		if present {
+			customer := customerFromCustomerDoc(customerDoc)
+			return &customer, nil
+		}
+		log.Printf("CustomerId=%s record does not exist in document store", customerID)
+		return nil, retrieving.CustomerNonExistent{CustomerID: customerID}
 	}
 }
 

--- a/internal/storage/mongo/customerdoc.go
+++ b/internal/storage/mongo/customerdoc.go
@@ -17,7 +17,7 @@ func InsertCustomer() storage.InsertCustomerFunc {
 
 // RetrieveCustomer returns a mongo implementation of customer retrieval
 func RetrieveCustomer() storage.RetrieveCustomerFunc {
-	return func(customerId string) retrieving.Customer {
+	return func(customerId string) (*retrieving.Customer, error) {
 		panic("Mongo retrieve not implemented yet")
 	}
 }

--- a/internal/workflow/retrieve.go
+++ b/internal/workflow/retrieve.go
@@ -6,14 +6,16 @@ import (
 )
 
 // RetrieveSingleFunc retrieves an existing customer with customerId from the datastore
-type RetrieveSingleFunc func(customerId string) retrieving.Customer
+// An error is returned when there is no corresponding customer record for customerId
+// Specifically, retrieving.CustomerNonExistent will be returned in that case.
+type RetrieveSingleFunc func(customerId string) (*retrieving.Customer, error)
 
 // RetrieveMultiFunc retrieves multiple customers that match the query describe in r.
 type RetrieveMultiFunc func(r retrieving.MultiRequest) []retrieving.Customer
 
 // RetrieveOne is the default implementation of the customer retrieve workflow
 func RetrieveOne(retrieveFromDb storage.RetrieveCustomerFunc) RetrieveSingleFunc {
-	return func(customerId string) retrieving.Customer {
+	return func(customerId string) (*retrieving.Customer, error) {
 		return retrieveFromDb(customerId)
 	}
 }

--- a/internal/workflow/retrieve_test.go
+++ b/internal/workflow/retrieve_test.go
@@ -9,24 +9,25 @@ import (
 )
 
 func TestRetrieveOne(t *testing.T) {
-	customerId := "fb57de5c-8679-476c-a546-6304a9fe5bb3"
-	expectedCustomer := retrieveFromDb(customerId)
+	customerID := "fb57de5c-8679-476c-a546-6304a9fe5bb3"
+	expectedCustomer, _ := retrieveFromDb(customerID)
 	retrieveOne := RetrieveOne(retrieveFromDb)
-	actualCustomer := retrieveOne(customerId)
+	actualCustomer, _ := retrieveOne(customerID)
 
-	if expectedCustomer != actualCustomer {
+	if *expectedCustomer != *actualCustomer {
 		t.Errorf("with customerId=%s, expectedCustomer=%+v actualCustomer=%+v",
-			customerId, expectedCustomer, actualCustomer)
+			customerID, *expectedCustomer, *actualCustomer)
 	}
 }
 
-func retrieveFromDb(customerId string) retrieving.Customer {
-	return mockCustomer(customerId)
+func retrieveFromDb(customerID string) (*retrieving.Customer, error) {
+	customer := mockCustomer(customerID)
+	return &customer, nil
 }
 
-func mockCustomer(customerId string) retrieving.Customer {
+func mockCustomer(customerID string) retrieving.Customer {
 	return retrieving.Customer{
-		CustomerId:       customerId,
+		CustomerId:       customerID,
 		FirstName:        "John",
 		LastName:         "Doe",
 		NationalId:       "9876543",
@@ -35,6 +36,20 @@ func mockCustomer(customerId string) retrieving.Customer {
 		LastModifiedTime: "2019-07-05T01:39:36+01:00",
 		CreatedTime:      "2019-07-05T01:39:36+01:00",
 		Version:          0,
+	}
+}
+
+func TestRetrieveOneError(t *testing.T) {
+	customerID := "45dca513-c40f-4f9c-b7b4-1b2e385b343d"
+	expectedError := retrieving.CustomerNonExistent{CustomerID: customerID}
+	retrieveFromDb := func(cID string) (*retrieving.Customer, error) {
+		return nil, expectedError
+	}
+	retrieveOne := RetrieveOne(retrieveFromDb)
+	_, err := retrieveOne(customerID)
+
+	if expectedError != err {
+		t.Errorf("Expecting error %s but got %s", expectedError, err)
 	}
 }
 


### PR DESCRIPTION
So far the retrieve one workflow was implemented with only success cases.
This commit adds error handling for the case where the requested
record for a customer does not exist. We also add the coresponding
API error handling with CustomerNonExistent error is propagated up.