### PR TITLE
Add error handling for firstName for create API

### DIFF
--- a/internal/adding/customer.go
+++ b/internal/adding/customer.go
@@ -1,13 +1,12 @@
 package adding
 
-// An UnPersistedCustomer is the value of a customer pre database persistence
-type UnPersistedCustomer struct {
-	FirstName   string
-	LastName    string
-	NationalId  string
-	PhoneNumber string
-	AccountId   string
-}
+import (
+	"fmt"
+
+	"github.com/albertowusuasare/customer-app/internal/validation"
+)
+
+type firstName string
 
 // A PersistedCustomer is the value of a customer post database persistence
 type PersistedCustomer struct {
@@ -17,4 +16,29 @@ type PersistedCustomer struct {
 	NationalId  string
 	PhoneNumber string
 	AccountId   string
+}
+
+/* Simple type constructors */
+
+// CreateFirstName validates v and returns a firstname
+// An error is returned if v is an invalid firstname
+func CreateFirstName(v string) (firstName, error) {
+	if v == "" {
+		return "", fmt.Errorf("Firstname cannot be empty")
+	}
+
+	if !validation.IsUTFAlpahnumeric(v) {
+		return "", fmt.Errorf("Firstname must be alphanumeric")
+	}
+
+	if !validation.IsLengthLessOrEqual(v, 64) {
+		return "", fmt.Errorf("FirstName legnth must be less than or equal to 64")
+	}
+
+	return firstName(v), nil
+}
+
+// RetrieveFirstName the underlying value for a firstName
+func RetrieveFirstName(f firstName) string {
+	return string(f)
 }

--- a/internal/adding/request.go
+++ b/internal/adding/request.go
@@ -1,8 +1,9 @@
 package adding
 
-// A Request is the unvalidated request to add a new customer.
-// A Request will need to be validated in order to consider it being persisted in the database
-type Request struct {
+import "github.com/albertowusuasare/customer-app/internal/validation"
+
+// An UnvalidatedRequest is the unvalidated request to add a new customer.
+type UnvalidatedRequest struct {
 	FirstName   string
 	LastName    string
 	NationalId  string
@@ -10,11 +11,37 @@ type Request struct {
 	AccountId   string
 }
 
-// A RequestValidatorFunc exposes functionaltiy to validate an incoming add request.
-// The output of the validator is the UnPersistedCustomer to be saved if no errors are encountered.
-type RequestValidatorFunc func(r Request) (UnPersistedCustomer, error)
+// A ValidatedRequest is the value of a customer add request post validation
+type ValidatedRequest struct {
+	FirstName   firstName
+	LastName    string
+	NationalId  string
+	PhoneNumber string
+	AccountId   string
+}
 
-// RequestToUnPersistedCustomer is the primary validator for incoming customer add requests.
-func RequestToUnPersistedCustomer(r Request) (UnPersistedCustomer, error) {
-	return UnPersistedCustomer(r), nil
+// A RequestValidatorFunc exposes functionaltiy to validate an incoming add request.
+type RequestValidatorFunc func(r UnvalidatedRequest) (ValidatedRequest, error)
+
+// ValidateRequest is the primary validator for incoming customer add requests.
+func ValidateRequest(r UnvalidatedRequest) (ValidatedRequest, error) {
+	failedFields := map[validation.FieldName]validation.Message{}
+	firstName, err := CreateFirstName(r.FirstName)
+
+	if err != nil {
+		failedFields[validation.FieldName("firstName")] = validation.Message(err.Error())
+	}
+
+	if len(failedFields) != 0 {
+		validationError := validation.Error{Fields: failedFields}
+		return ValidatedRequest{}, validationError
+	}
+
+	return ValidatedRequest{
+		FirstName:   firstName,
+		LastName:    r.LastName,
+		NationalId:  r.NationalId,
+		PhoneNumber: r.PhoneNumber,
+		AccountId:   r.AccountId,
+	}, nil
 }

--- a/internal/api/error.go
+++ b/internal/api/error.go
@@ -1,0 +1,18 @@
+package api
+
+// ErrorCode is a machine friendly description of the error
+type ErrorCode string
+
+// ErrorMessage is a human friendly description of the error
+type ErrorMessage string
+
+// ErrorParams captures an additional key value pairs of information about an error
+type ErrorParams map[string]string
+
+// An Error is a representation of an api error
+// Errors include but not limited to domain errors, validation, authentication error etc
+type Error struct {
+	Code    ErrorCode    `json:"code"`
+	Message ErrorMessage `json:"message"`
+	Params  ErrorParams  `json:"params"`
+}

--- a/internal/api/errorcode.go
+++ b/internal/api/errorcode.go
@@ -1,0 +1,4 @@
+package api
+
+// InvalidRequestBody is a constant for an invalid request body error
+var InvalidRequestBody = ErrorCode("invalid_request_body")

--- a/internal/api/errormsg.go
+++ b/internal/api/errormsg.go
@@ -1,0 +1,7 @@
+package api
+
+// Defaut application error messages
+const (
+	EmptyErrorMessage           = ErrorMessage("")
+	InputValidationErrorMessage = ErrorMessage("One or more input values are invalid. Please re-renter valid values")
+)

--- a/internal/app/inmem.go
+++ b/internal/app/inmem.go
@@ -10,7 +10,7 @@ import (
 
 // Inmem creates a customer app based on in memory data store
 func Inmem() Customer {
-	createWf := workflow.Create(adding.RequestToUnPersistedCustomer, uuid.Gen(), inmem.InsertCustomer(), queue.CustomerAddedPublisher())
+	createWf := workflow.Create(adding.ValidateRequest, uuid.Gen(), inmem.InsertCustomer(), queue.CustomerAddedPublisher())
 	retrieveSingleWf := workflow.RetrieveOne(inmem.RetrieveCustomer())
 	retrieveMultiWf := workflow.RetrieveMulti(inmem.RetrieveCustomers())
 	updateWf := workflow.Update(inmem.UpdateCustomer(), queue.CustomerUpdatedPublisher())

--- a/internal/storage/customer.go
+++ b/internal/storage/customer.go
@@ -9,7 +9,7 @@ import (
 
 // InsertCustomerFunc adds a new customer to a permaent data store.
 // A unique id for the customer will be generated using genUUIDStr
-type InsertCustomerFunc func(unPersistedCustomer adding.UnPersistedCustomer, genUUIDStr uuid.GenFunc) adding.PersistedCustomer
+type InsertCustomerFunc func(request adding.ValidatedRequest, genUUIDStr uuid.GenFunc) adding.PersistedCustomer
 
 // RetrieveCustomerFunc retrieve a customer in the data store corresponding to customerId
 // when error is nil. An error is returned if a customer record cannot be found for customerId.

--- a/internal/storage/inmem/customerdoc.go
+++ b/internal/storage/inmem/customerdoc.go
@@ -29,8 +29,8 @@ var customerCollection = map[string]CustomerDocument{}
 
 //InsertCustomer returns an imemory implementation for customer inserts
 func InsertCustomer() storage.InsertCustomerFunc {
-	return func(customer adding.UnPersistedCustomer, genUUIDStr uuid.GenFunc) adding.PersistedCustomer {
-		customerDoc := customerDocumentFromUnPersistedCustomer(customer, genUUIDStr)
+	return func(request adding.ValidatedRequest, genUUIDStr uuid.GenFunc) adding.PersistedCustomer {
+		customerDoc := customerDocumentFromValidatedRequest(request, genUUIDStr)
 		fmt.Printf("Adding customerDoc=%+v to in memory database\n", customerDoc)
 		customerCollection[customerDoc.CustomerId] = customerDoc
 		return adding.PersistedCustomer{
@@ -44,14 +44,14 @@ func InsertCustomer() storage.InsertCustomerFunc {
 	}
 }
 
-func customerDocumentFromUnPersistedCustomer(customer adding.UnPersistedCustomer, genUUIDStr uuid.GenFunc) CustomerDocument {
+func customerDocumentFromValidatedRequest(request adding.ValidatedRequest, genUUIDStr uuid.GenFunc) CustomerDocument {
 	return CustomerDocument{
 		CustomerId:       genUUIDStr(),
-		FirstName:        customer.FirstName,
-		LastName:         customer.LastName,
-		NationalId:       customer.NationalId,
-		PhoneNumber:      customer.PhoneNumber,
-		AccountId:        customer.AccountId,
+		FirstName:        adding.RetrieveFirstName(request.FirstName),
+		LastName:         request.LastName,
+		NationalId:       request.NationalId,
+		PhoneNumber:      request.PhoneNumber,
+		AccountId:        request.AccountId,
 		LastModifiedTime: time.Now().Format(time.RFC3339),
 		CreatedTime:      time.Now().Format(time.RFC3339),
 		Version:          0,

--- a/internal/storage/mongo/customerdoc.go
+++ b/internal/storage/mongo/customerdoc.go
@@ -10,7 +10,7 @@ import (
 
 //InsertCustomer returns a mongo implementation for customer inserts
 func InsertCustomer() storage.InsertCustomerFunc {
-	return func(unPersistedCustomer adding.UnPersistedCustomer, genUUIDStr uuid.GenFunc) adding.PersistedCustomer {
+	return func(request adding.ValidatedRequest, genUUIDStr uuid.GenFunc) adding.PersistedCustomer {
 		panic("Mongo insert not implemented yet")
 	}
 }

--- a/internal/validation/field.go
+++ b/internal/validation/field.go
@@ -1,0 +1,67 @@
+package validation
+
+import "fmt"
+
+// FieldName is the name of the field that failed validation
+type FieldName string
+
+// Message is the message describing the field validation failure
+type Message string
+
+// Fields is a key value collection of the names of all failed fields
+// and their corresponding failure messages
+type Fields map[FieldName]Message
+
+// Implemententors of FieldValidation adds a means to get validation error fields from an error
+type fieldValidationFailure interface {
+	FailedFields() Fields
+}
+
+// Error is a representation of all input validation errors when initializing a workflow
+type Error struct {
+	Fields map[FieldName]Message
+}
+
+// FailedFields returns the fields that failed validation
+func (v Error) FailedFields() Fields {
+	result := map[FieldName]Message{}
+	for k, v := range v.Fields {
+		result[FieldName(k)] = Message(v)
+	}
+	return result
+}
+
+// Error adds the error behavior to ValidationError
+func (v Error) Error() string {
+	return fmt.Sprintf("Validation error has fields %s", v.Fields)
+
+}
+
+// IsFieldValidationError returns trye if the error is of type fieldValidationFailure
+func IsFieldValidationError(err error) bool {
+	_, ok := err.(fieldValidationFailure)
+	return ok
+}
+
+// GetFailedValidationFields returns the failed validation fields or error if the error
+// is not a fieldValidationFailure
+func GetFailedValidationFields(err error) (map[FieldName]Message, error) {
+	ve, ok := err.(fieldValidationFailure)
+
+	if ok {
+		return ve.FailedFields(), nil
+	}
+
+	return map[FieldName]Message{},
+		fmt.Errorf("Unable to obtain failued validation fields from non field validation error %+v", err)
+}
+
+// RetrieveFieldName returns the underlying field name for f
+func RetrieveFieldName(f FieldName) string {
+	return string(f)
+}
+
+// RetrieveMessage returns the underlying message for m
+func RetrieveMessage(m Message) string {
+	return string(m)
+}

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -1,0 +1,19 @@
+package validation
+
+import "unicode"
+
+// IsUTFAlpahnumeric checks if the string contains only unicode letters and numbers. Empty string is valid.
+func IsUTFAlpahnumeric(s string) bool {
+	if s == "" {
+		return true
+	}
+	chars := []rune(s)
+	f := chars[0]
+	return (unicode.IsLetter(f) || unicode.IsNumber(f)) &&
+		IsUTFAlpahnumeric(string(chars[1:]))
+}
+
+// IsLengthLessOrEqual checks if the string has length less than max
+func IsLengthLessOrEqual(s string, max int) bool {
+	return len(s) <= max
+}

--- a/test/data/validation/create-empty-firstname-request.json
+++ b/test/data/validation/create-empty-firstname-request.json
@@ -1,0 +1,7 @@
+{
+	"firstName": "",
+	"lastName": "Doe",
+	"nationalId": "12345779",
+	"phoneNumber": "82876337",
+	"accountId": "58dd83f8-1482-4a76-a4a5-99e5e3fd3168"
+}

--- a/test/data/validation/create-empty-firstname-response.json
+++ b/test/data/validation/create-empty-firstname-response.json
@@ -1,0 +1,7 @@
+{
+    "code": "invalid_request_body",
+    "message": "One or more input values are invalid. Please re-renter valid values",
+    "params": {
+        "firstName": "Firstname cannot be empty"
+    }
+}

--- a/test/data/validation/create-long-length-request.json
+++ b/test/data/validation/create-long-length-request.json
@@ -1,0 +1,7 @@
+{
+	"firstName": "addfdafdadfadsfasdfadsfasdfasdfafadfasdfasdfasdfasdfasdfasdfajnkh",
+	"lastName": "Doe",
+	"nationalId": "12345779",
+	"phoneNumber": "82876337",
+	"accountId": "58dd83f8-1482-4a76-a4a5-99e5e3fd3168"
+}

--- a/test/data/validation/create-long-length-response.json
+++ b/test/data/validation/create-long-length-response.json
@@ -1,0 +1,7 @@
+{
+    "code": "invalid_request_body",
+    "message": "One or more input values are invalid. Please re-renter valid values",
+    "params": {
+        "firstName": "FirstName legnth must be less than or equal to 64"
+    }
+}

--- a/test/data/validation/create-nonalphanumeric-firstname-request.json
+++ b/test/data/validation/create-nonalphanumeric-firstname-request.json
@@ -1,0 +1,7 @@
+{
+	"firstName": "$$$",
+	"lastName": "Doe",
+	"nationalId": "12345779",
+	"phoneNumber": "82876337",
+	"accountId": "58dd83f8-1482-4a76-a4a5-99e5e3fd3168"
+}

--- a/test/data/validation/create-nonalphanumeric-firstname-response.json
+++ b/test/data/validation/create-nonalphanumeric-firstname-response.json
@@ -1,0 +1,7 @@
+{
+    "code": "invalid_request_body",
+    "message": "One or more input values are invalid. Please re-renter valid values",
+    "params": {
+        "firstName": "Firstname must be alphanumeric"
+    }
+}


### PR DESCRIPTION
Defined a custom error payload that provides more context to the API caller about what occured.
The payload contains a top level code string, a human readable message and a param field for
any extra contexts.